### PR TITLE
Parameter formatting fixes

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -92,20 +92,20 @@
   * [Flat Kick Incentive](parameter-index/collateral-auction/param-flat-kick-incentive.md)
 
 * Surplus Auction
-  * [Surplus Lot Size](parameter-index/surplus-auction/param-surplus-lot-size.md)
-  * [Min Bid Increase](parameter-index/surplus-auction/param-min-bid-increase-flap.md)
-  * [Auction Duration](parameter-index/surplus-auction/param-auction-duration-flap.md)
-  * [Bid Duration](parameter-index/surplus-auction/param-bid-duration-flap.md)
+  * [Surplus Auction Lot Size](parameter-index/surplus-auction/param-surplus-lot-size.md)
+  * [Surplus Auction Minimum Bid Increase](parameter-index/surplus-auction/param-min-bid-increase-flap.md)
+  * [Surplus Auction Duration](parameter-index/surplus-auction/param-auction-duration-flap.md)
+  * [Surplus Auction Bid Duration](parameter-index/surplus-auction/param-bid-duration-flap.md)
   * [Surplus Auction Limit](parameter-index/surplus-auction/param-surplus-auction-limit.md)
 
 * Debt Auction
-  * [Min Bid Decrease](parameter-index/debt-auction/param-min-bid-decrease-flop.md)
-  * [Auction Duration](parameter-index/debt-auction/param-auction-duration-flop.md)
-  * [Bid Duration](parameter-index/debt-auction/param-bid-duration-flop.md)
+  * [Debt Auction Minimum Bid Decrease](parameter-index/debt-auction/param-min-bid-decrease-flop.md)
+  * [Debt Auction Duration](parameter-index/debt-auction/param-auction-duration-flop.md)
+  * [Debt Auction Bid Duration](parameter-index/debt-auction/param-bid-duration-flop.md)
   * [Debt Auction Delay](parameter-index/debt-auction/param-debt-auction-delay.md)
   * [Debt Auction Bid Size](parameter-index/debt-auction/param-bid-size.md)
-  * [Initial Lot Size](parameter-index/debt-auction/param-initial-lot-size.md)
-  * [Lot Size Increased](parameter-index/debt-auction/param-lot-size-increase.md)
+  * [Debt Auction Initial Lot Size](parameter-index/debt-auction/param-initial-lot-size.md)
+  * [Debt Auction Lot Size Increase](parameter-index/debt-auction/param-lot-size-increase.md)
 
 
 ## Module Index

--- a/module-index/module-flash-mint-module.md
+++ b/module-index/module-flash-mint-module.md
@@ -3,7 +3,7 @@
 >**Alias:** Flash  
 >**Contract Name:** DSSFlash  
 >**Scope:** System  
->**Technical Docs:** https://docs.makerdao.com/smart-contract-modules/flash-mint-module  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/flash-mint-module)  
 
 ## Description
 

--- a/module-index/module-lerp.md
+++ b/module-index/module-lerp.md
@@ -4,7 +4,7 @@
 >**Alias:** `lerp`  
 >**Contract Name:** `dss-lerp`  
 >**Scope:** One instance for each parameter  
->**Technical docs:** https://github.com/makerdao/dss-lerp  
+>**Technical docs:** [link](https://github.com/makerdao/dss-lerp)  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-auction-price-function.md
+++ b/parameter-index/collateral-auction/param-auction-price-function.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `calc`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-auction-price-function.md
+++ b/parameter-index/collateral-auction/param-auction-price-function.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `calc`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:** -  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-auction-price-multiplier.md
+++ b/parameter-index/collateral-auction/param-auction-price-multiplier.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `buf`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-auction-price-multiplier.md
+++ b/parameter-index/collateral-auction/param-auction-price-multiplier.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `buf`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:** -  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-breaker-price-tolerance.md
+++ b/parameter-index/collateral-auction/param-breaker-price-tolerance.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `tolerance`  
 >**Containing Contract:** `ClipperMom`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-flat-kick-incentive.md
+++ b/parameter-index/collateral-auction/param-flat-kick-incentive.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `tip`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-flat-kick-incentive.md
+++ b/parameter-index/collateral-auction/param-flat-kick-incentive.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `tip`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:** -  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-local-liquidation-limit.md
+++ b/parameter-index/collateral-auction/param-local-liquidation-limit.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `hole`  
 >**Containing Contract:** `Dog`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:** -  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  >**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-local-liquidation-limit.md
+++ b/parameter-index/collateral-auction/param-local-liquidation-limit.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `hole`  
 >**Containing Contract:** `Dog`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-local-liquidation-limit.md
+++ b/parameter-index/collateral-auction/param-local-liquidation-limit.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `hole`  
 >**Containing Contract:** `Dog`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  >**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)   
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-max-auction-drawdown.md
+++ b/parameter-index/collateral-auction/param-max-auction-drawdown.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `cusp`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-max-auction-drawdown.md
+++ b/parameter-index/collateral-auction/param-max-auction-drawdown.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `cusp`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:** -  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-max-auction-duration.md
+++ b/parameter-index/collateral-auction/param-max-auction-duration.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `tail`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-max-auction-duration.md
+++ b/parameter-index/collateral-auction/param-max-auction-duration.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `tail`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:** -  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-proportional-kick-incentive.md
+++ b/parameter-index/collateral-auction/param-proportional-kick-incentive.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `chip`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/collateral-auction/param-proportional-kick-incentive.md
+++ b/parameter-index/collateral-auction/param-proportional-kick-incentive.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `chip`  
 >**Containing Contract:** `Clipper`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:** -  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation)  
 
 ## Description
 

--- a/parameter-index/core/param-global-liquidation-limit.md
+++ b/parameter-index/core/param-global-liquidation-limit.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `Hole`  
 >**Containing Contract:** `Dog`  
 >**Scope:** System  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 

--- a/parameter-index/debt-auction/param-bid-size.md
+++ b/parameter-index/debt-auction/param-bid-size.md
@@ -1,10 +1,10 @@
 # Debt Auction Bid Size
 
->**Alias:  
->**Parameter Name: `sump`  
->**Containing Contract: Vow  
->**Scope: System  
->**Technical Docs: https://docs.makerdao.com/smart-contract-modules/system-stabilizer-module/vow-detailed-documentation
+>**Alias:** N/A  
+>**Parameter Name:** `sump`  
+>**Containing Contract:** `Vow`  
+>**Scope:** System  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/system-stabilizer-module/vow-detailed-documentation)  
 
 ## Description
 Debt Auctions are used to recapitalize the system by minting and auctioning off MKR for a fixed amount of DAI. In this process, keepers bid on how little MKR they are willing to accept for the fixed Dai amount they have to pay at auction settlement. During debt auctions, the fixed amount of Dai to be covered by any debt auction is determined by the `Debt Auction Bid Size` parameter.
@@ -23,10 +23,10 @@ A large `Debt Auction Bid Size` keeps the protocol undercollateralized for longe
 ## Changes
 Adjusting the `Debt Auction Bid Size` parameter is a manual process that requires an executive vote. Changes to the `Debt Auction Bid Size` are subject to the GSM Pause Delay.
 
-**Why increase this parameter?**
+**Why increase this parameter?**  
 Maker Governance may wish to increase the `Debt Auction Bid Size` if gas costs for keepers are too high or if the number of debt auctions that may occur in parallel is too large.
 
-**Why decrease this parameter?**
+**Why decrease this parameter?**  
 Maker Governance may wish to decrease the `Debt Auction Bid Size` if there is insufficient keeper participation or to keep the protocol undercollateralized for a shorter duration.
 
 >Page last reviewed: -  

--- a/parameter-index/debt-auction/param-debt-auction-delay.md
+++ b/parameter-index/debt-auction/param-debt-auction-delay.md
@@ -1,8 +1,8 @@
 # Debt Auction Delay
 
 >**Alias:** Flop Delay  
->**Parameter Name:** wait  
->**Containing Contract:** Vow  
+>**Parameter Name:** `wait`  
+>**Containing Contract:** `Vow`  
 >**Scope:** System  
 >**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/system-stabilizer-module/vow-detailed-documentation)  
 

--- a/parameter-index/debt-auction/param-initial-lot-size.md
+++ b/parameter-index/debt-auction/param-initial-lot-size.md
@@ -1,12 +1,10 @@
----
 # Debt Auction Initial Lot Size
 
-
->**Alias:  
->**Parameter Name: `dump`  
->**Containing Contract: Vow  
->**Scope: System  
->**Technical Docs: https://docs.makerdao.com/smart-contract-modules/system-stabilizer-module/vow-detailed-documentation  
+>**Alias:** N/A  
+>**Parameter Name:** `dump`  
+>**Containing Contract:** `Vow`  
+>**Scope:** System  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/system-stabilizer-module/vow-detailed-documentation)  
 
 
 ## Description
@@ -26,10 +24,10 @@ A large `Debt Auction Initial Lot Size` could result in large amounts of MKR min
 ## Changes
 Adjusting the `Debt Auction Initial Lot Size` parameter is a manual process that requires an executive vote. Changes to the `Debt Auction Initial Lot Size` are subject to the GSM Pause Delay.
 
-**Why increase this parameter?**
+**Why increase this parameter?**  
 Maker Governance may wish to increase the `Debt Auction Initial Lot Size` if debt auctions have to be repeated restarted before keepers are able to submit profitable bids.
 
-**Why decrease this parameter?**
+**Why decrease this parameter?**  
 Maker Governance may wish to decrease the `Debt Auction Initial Lot Size` if there is a risk of insufficient keeper participation resulting in a risk of high amounts of MKR being minted.
 
 ## Considerations

--- a/parameter-index/debt-auction/param-initial-lot-size.md
+++ b/parameter-index/debt-auction/param-initial-lot-size.md
@@ -8,7 +8,9 @@
 
 
 ## Description
-Debt Auctions are used to recapitalize the system by minting and auctioning off MKR for a fixed amount of DAI. In this process, keepers bid on how little MKR they are willing to accept for the fixed Dai amount they have to pay at auction settlement. The starting amount of MKR in these auctions is determined by the `Debt Auction Initial Lot Size` parameter. Auction participants may bid a lower amount of MKR than the initial lot size. If there are no bids, they must wait for the duration of the auction before the auction can be restarted with a higher `Debt Auction Initial Lot Size`. This increase is determined by the `pad` parameter. 
+Debt Auctions are used to recapitalize the system by minting and auctioning off MKR for a fixed amount of DAI. In this process, keepers bid on how little MKR they are willing to accept for the fixed Dai amount they have to pay at auction settlement. The starting amount of MKR in these auctions is determined by the `Debt Auction Initial Lot Size` parameter.
+
+Auction participants may bid a lower amount of MKR than the initial lot size. If there are no bids, they must wait for the duration of the auction before the auction can be restarted with a higher `Debt Auction Initial Lot Size`. This increase is determined by the `pad` parameter. 
 
 
 ## Purpose

--- a/parameter-index/debt-auction/param-lot-size-increase.md
+++ b/parameter-index/debt-auction/param-lot-size-increase.md
@@ -1,11 +1,10 @@
----
 # Debt Auction Lot Size Increase
 
->**Alias:  
->**Parameter Name: `pad`  
->**Containing Contract: Flopper  
->**Scope: System  
->**Technical Docs: https://docs.makerdao.com/smart-contract-modules/system-stabilizer-module/flop-detailed-documentation
+>**Alias:** N/A  
+>**Parameter Name:** `pad`  
+>**Containing Contract:** `Flop`  
+>**Scope:** System  
+>**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/system-stabilizer-module/flop-detailed-documentation)
 
 ## Description
 Debt Auctions are used to recapitalize the system by minting and auctioning off MKR for a fixed amount of DAI. In this process, keepers bid on how little MKR they are willing to accept for the fixed Dai amount they have to pay at auction settlement. The starting amount of MKR in these auctions is determined by the `Debt Auction Initial Lot Size` parameter. Auction participants may bid a lower amount of MKR than the initial lot size. If there are no bids, they must wait for the duration of the auction before the auction can be restarted with a higher `Debt Auction Initial Lot Size`. This increase is determined by the `Debt Auction Lot Size Increase` parameter. 
@@ -27,10 +26,10 @@ A large `Debt Auction Lot Size Increase` could result in large amounts of MKR mi
 ## Changes
 Adjusting the `Debt Auction Lot Size Increase` parameter is a manual process that requires an executive vote. Changes to the `Debt Auction Lot Size Increase` are subject to the GSM Pause Delay.
 
-**Why increase this parameter?**
+**Why increase this parameter?**  
 Maker Governance may wish to increase the `Debt Auction Lot Size Increase` if debt auctions have to be repeated restarted before keepers are able to submit profitable bids.
 
-**Why decrease this parameter?**
+**Why decrease this parameter?**  
 Maker Governance may wish to decrease the `Debt Auction Lot Size Increase` if there is a risk of insufficient keeper participation resulting in a risk of high amounts of MKR being minted.
 
 

--- a/parameter-index/debt-auction/param-lot-size-increase.md
+++ b/parameter-index/debt-auction/param-lot-size-increase.md
@@ -7,7 +7,9 @@
 >**Technical Docs:** [link](https://docs.makerdao.com/smart-contract-modules/system-stabilizer-module/flop-detailed-documentation)
 
 ## Description
-Debt Auctions are used to recapitalize the system by minting and auctioning off MKR for a fixed amount of DAI. In this process, keepers bid on how little MKR they are willing to accept for the fixed Dai amount they have to pay at auction settlement. The starting amount of MKR in these auctions is determined by the `Debt Auction Initial Lot Size` parameter. Auction participants may bid a lower amount of MKR than the initial lot size. If there are no bids, they must wait for the duration of the auction before the auction can be restarted with a higher `Debt Auction Initial Lot Size`. This increase is determined by the `Debt Auction Lot Size Increase` parameter. 
+Debt Auctions are used to recapitalize the system by minting and auctioning off MKR for a fixed amount of DAI. In this process, keepers bid on how little MKR they are willing to accept for the fixed Dai amount they have to pay at auction settlement. The starting amount of MKR in these auctions is determined by the `Debt Auction Initial Lot Size` parameter. 
+
+Auction participants may bid a lower amount of MKR than the initial lot size. If there are no bids, they must wait for the duration of the auction before the auction can be restarted with a higher `Debt Auction Initial Lot Size`. This increase is determined by the `Debt Auction Lot Size Increase` parameter. 
 
 ## Example
 If the `Debt Auction Initial Lot Size` is 100 MKR and the `Debt Auction Lot Size Increase` is 50%, then an auction that is restarted due to no bids can have an initial bid not exceeding 150 MKR. If there are still no bids, the auction can be restarted again with an initial bid not exceeding 225 MKR.

--- a/parameter-index/debt-auction/param-min-bid-decrease-flop.md
+++ b/parameter-index/debt-auction/param-min-bid-decrease-flop.md
@@ -15,7 +15,7 @@ During debt auctions, new MKR bids must be lower than the current MKR bid by at 
 In practice the Min Bid Decrease (Flop) represents both:
 * The maximum profit that keepers can make when bidding in Debt Auctions. 
 * The maximum slippage MakerDAO is willing to accept during auctions to ensure sufficient keeper participation. 
-* 
+
 ### Example
 
 `Min Bid Decrease (Flop)` =5% 

--- a/parameter-index/surplus-auction/param-surplus-auction-limit.md
+++ b/parameter-index/surplus-auction/param-surplus-auction-limit.md
@@ -5,7 +5,7 @@
 >**Parameter Name:** `lid`  
 >**Containing Contract:** `Flap`  
 >**Scope:** System  
->**Technical Docs:**   
+>**Technical Docs:** -   
 
 
 ## Description

--- a/parameter-index/surplus-auction/param-surplus-auction-limit.md
+++ b/parameter-index/surplus-auction/param-surplus-auction-limit.md
@@ -1,11 +1,11 @@
 
 # Surplus Auction Limit   
 
->Alias:N/A   
->Parameter Name: `lid`  
->Containing Contract: `Flap`  
->Scope: System  
->Technical Docs:   
+>**Alias:** N/A   
+>**Parameter Name:** `lid`  
+>**Containing Contract:** `Flap`  
+>**Scope:** System  
+>**Technical Docs:**   
 
 
 ## Description

--- a/parameter-index/vault-risk/param-liquidation-penalty.md
+++ b/parameter-index/vault-risk/param-liquidation-penalty.md
@@ -4,7 +4,7 @@
 >**Parameter Name:** `chop`  
 >**Containing Contract:** `Dog`  
 >**Scope:** Vault Type (Ilk)  
->**Technical Docs:**  
+>**Technical Docs:** -  
 
 ## Description
 


### PR DESCRIPTION
Note, the summary.md has to change because gitbook takes page titles from that md file, rather than from the page md itself. 

Otherwise largely misc changes to improve formatting. Present on staging: https://longforwisdom.gitbook.io/new-collection/
