### PR TITLE
add Google Calendar Embed to MOM

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,7 +11,9 @@
   * [Status and Dashboards](protocol-status/protocol-and-dao-status.md)
   * [Core Unit Budget Flow](core-units/core-unit-budget-flow.md)
   * [Common Abbreviations and Acronyms](protocol-status/acronyms.md)
-
+  
+* Calendar
+  * [Official MakerDAO Google Calendar](protocol-status/calendar.md)
 
 ## Governance
 * Governance Cycle
@@ -46,6 +48,7 @@
   * [Separation of Powers](delegation/separation-of-powers.md)
   * [Delegate Metric Tracking](delegation/delegate-metric-tracking.md)
 * For MKR Holders
+  * [How to Delegate Video](delegation/mkr-holder-HowToDelegate.md)
   * [MKR Holders Guide to Delegation](delegation/mkr-holder-guide.md)
   * [MKR Holders Agreement](delegation/mkr-holder-agreement.md)
   * [How To Delegate Video](delegation/mkr-holder-how-to-delegate.md)

--- a/protocol-status/calendar.md
+++ b/protocol-status/calendar.md
@@ -1,0 +1,6 @@
+# Official MakerDAO Google Calendar
+
+The following is an embed of the Official MakerDAO Calendar which is maintained by the GovAlpha and GovComms Core Units. Please note all times are in Coordinated Universal Time (UTC). You may add events to your own personal Google Calendar using the button in the bottom-right.
+
+{% embed url="https://calendar.google.com/calendar/embed?src=makerdao.com_3efhm2ghipksegl009ktniomdk%40group.calendar.google.com&ctz=UTC&hl=en" %}
+	


### PR DESCRIPTION
Given this is the English language I've forced localization to English (noticed by Prose opening the staging version while in Barcelona that everything was localised to Spanish). We can switch this to Spanish if porting to the Spanish manual version.

On staging here: https://longforwisdom.gitbook.io/new-collection/makerdao/calendar/calendar

Pending: needs review to ensure it doesn't open us to any vulnerabilities e.g. from malicious event creation in the Maker Calendar. Will get Hernando to take a look.